### PR TITLE
Fix migration script bugs

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -42,6 +42,9 @@ while ! mongo --eval "db.runCommand( { serverStatus: 1 } )"; do
     sleep 1;
 done
 
+echo "preparing empty db so we can restore"
+mongo --eval "rs.initiate()"
+
 echo "Restore dump into wiredTiger instance..."
 mongorestore --drop --archive=/tmp/mmap --gzip --noIndexRestore
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -31,7 +31,7 @@ done
 echo "Remove existing mmap database files"
 rm -rf /data/db/*
 
-wiredTigerArgs="mongod --smallfiles --oplogSize 128 --replSet rs0 --storageEngine=wiredWiger --bind_ip_all"
+wiredTigerArgs="mongod --smallfiles --oplogSize 128 --replSet rs0 --storageEngine=wiredTiger --bind_ip_all"
 wiredTigerArgsArr=($wiredTigerArgs)
 echo "Start wiredTiger instance in background..."
 exec $wiredTigerArgsArr &


### PR DESCRIPTION
Hi,

when trying the script as a set of instructions, I noticed two things that kept the script from suceeding
1. there was a typo, preventing mongod from starting
2. since rs.initiate() was not run but mongod was started with rs0, restore could not begin